### PR TITLE
reaname `config.ini` to `default_config.ini` in installer

### DIFF
--- a/installer/setup.wxs
+++ b/installer/setup.wxs
@@ -107,7 +107,7 @@
 			</Component>
 
 			<Component Id="CONFIG" Guid="affde892-80fe-4008-b7bb-729ca98388c5">
-				<File Id="CONFIG" KeyPath="yes" Source="..\release\config.ini" />
+				<File Id="CONFIG" KeyPath="yes" Source="..\release\default_config.ini" />
 			</Component>
 
 			<!-- Required (?) DLLs -->

--- a/quickkey.pro
+++ b/quickkey.pro
@@ -22,7 +22,7 @@ style_sheets.path = $$OUT_PWD/release/style_sheets
 resources.files = $$files(src/resources/*)
 resources.path = $$OUT_PWD/release/resources
 
-config.files = src/config.ini
+config.files = src/default_config.ini
 config.path = $$OUT_PWD/release/
 
 # You can make your code fail to compile if you use deprecated APIs.


### PR DESCRIPTION
Changes to #36 